### PR TITLE
NO-TICKET: Removing error return and not encoding the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	// Generate token that is valid for 60 seconds using the default secret
-	token := ft.GenerateToken("RmFzdGx5IFRva2VuIFRlc3Q=", 60*time.Second, base64.StdEncoding); err != nil {
+	token := ft.GenerateToken("RmFzdGx5IFRva2VuIFRlc3Q=", 60*time.Second, base64.StdEncoding)
 	fmt.Printf("Token: %s\n", token)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ func main() {
 
 ## Benchmarks
 ```shell
-BenchmarkGenerateToken-8   	 1000000	      1770 ns/op
+BenchmarkGenerateToken-8   	 1000000	      1771 ns/op	     848 B/op	      12 allocs/op
 PASS
-ok  	github.com/zencoder/fastly-tokens/ft	2.004s
+ok  	github.com/zencoder/fastly-tokens/ft	2.101s
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -20,32 +20,28 @@ import (
 
 func main() {
 	// Generate token that is valid for 60 seconds using the default secret
-	var token string
-	var err error
-	if token, err = ft.GenerateToken("RmFzdGx5IFRva2VuIFRlc3Q=", 60*time.Second, base64.StdEncoding); err != nil {
-		log.Fatal("Error while generating token", err)
-	}
+	token := ft.GenerateToken("RmFzdGx5IFRva2VuIFRlc3Q=", 60*time.Second, base64.StdEncoding); err != nil {
 	fmt.Printf("Token: %s\n", token)
 }
 ```
 
 ## Benchmarks
 ```shell
+BenchmarkGenerateToken-8   	 1000000	      1728 ns/op
 PASS
-BenchmarkGenerateToken    200000        6523 ns/op
-ok    github.com/zencoder/fastly-tokens/ft  1.551s
+ok  	github.com/zencoder/fastly-tokens/ft	1.954s
 ```
 
 ## Development
 
 ### Dependencies
 
-Tested on go 1.5.3.
+Tested on go 1.7.1.
 
 ### Build and run unit tests
 
     make test
-    
+
 ### CI
 
 [This library builds on Circle CI, here.](https://circleci.com/gh/zencoder/fastly-tokens/)

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ func main() {
 
 ## Benchmarks
 ```shell
-BenchmarkGenerateToken-8   	 1000000	      1728 ns/op
+BenchmarkGenerateToken-8   	 1000000	      1770 ns/op
 PASS
-ok  	github.com/zencoder/fastly-tokens/ft	1.954s
+ok  	github.com/zencoder/fastly-tokens/ft	2.004s
 ```
 
 ## Development
 
 ### Dependencies
 
-Tested on go 1.7.1.
+Tested on go 1.7.4.
 
 ### Build and run unit tests
 

--- a/ft/fastly_token.go
+++ b/ft/fastly_token.go
@@ -46,7 +46,7 @@ if( !req.http.Fastly-FF && !((req.http.X-Expected-Sig == req.http.X-Token-Signat
 }
 
 */
-func GenerateTokenForURL(filename string, secret string, expiration time.Time, encoding *base64.Encoding) string {
+func GenerateTokenForURL(filename, secret string, expiration time.Time, encoding *base64.Encoding) string {
 	data := fmt.Sprintf("%s%x", filename, expiration.Unix())
 
 	mac := hmac.New(sha256.New, []byte(secret))

--- a/ft/fastly_token_test.go
+++ b/ft/fastly_token_test.go
@@ -18,10 +18,7 @@ func TestGenerateToken(t *testing.T) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 
-	token, err := GenerateToken("Fastly Token Test", 60*time.Second, base64.StdEncoding)
-	if err != nil {
-		t.Error("Error while generating token", err)
-	}
+	token := GenerateToken("Fastly Token Test", 60*time.Second, base64.StdEncoding)
 
 	if token != string(body) {
 		t.Errorf("Expected token: %s, Actual Token: %s", body, token)
@@ -38,10 +35,7 @@ func TestGenerateTokenForURL(t *testing.T) {
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 
-	token, err := GenerateTokenForURL("http://www.example.com/index.html", "0bgZZu4uzL1K2My1842DjuAvkJnE8j9s", time.Now(), base64.StdEncoding)
-	if err != nil {
-		t.Error("Error while generating token", err)
-	}
+	token := GenerateTokenForURL("http://www.example.com/index.html", "0bgZZu4uzL1K2My1842DjuAvkJnE8j9s", time.Now(), base64.StdEncoding)
 
 	if token == string(body) {
 		t.Error("Expected token mismatch between Fastly service token and URL-specific token", err)


### PR DESCRIPTION
Here I'm proposing that we avoid the URL encoding as this is not the responsibility of `GenerateTokenForURL`. The function name implies we are only generating and returning a token for the resource path passed -  Query escaping can happen after the fact if that's what the user desires.

For example when setting query params on a URL:
```
qv := resourceURL.Query()
qv.Set("fastly_token", ft.GenerateTokenForURL(resourceURL.Path, *secret, expiration, base64.URLEncoding))
resourceURL.RawQuery = qv.Encode()
```
Using the above code would result in a double query escaped string which is not what we want.

Also I've removed the returned errors as this isn't even possible.

These changes have resulted in a 4752 ns/op performance increase.