### PR TITLE
Stopped hex-encoding URL Regex

### DIFF
--- a/ft/fastly_token.go
+++ b/ft/fastly_token.go
@@ -70,7 +70,7 @@ func GenerateTokenForURLRegex(urlRegex, secret string, expiration time.Time, enc
 		"%x_%s_%s",
 		expiration.Unix(),
 		hex.EncodeToString(mac.Sum(nil)),
-		hex.EncodeToString([]byte(urlRegex)),
+		[]byte(urlRegex),
 	)
 
 	return strings.TrimSpace(encoding.EncodeToString([]byte(token)))

--- a/ft/fastly_token_test.go
+++ b/ft/fastly_token_test.go
@@ -2,7 +2,6 @@ package ft
 
 import (
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -77,12 +76,8 @@ func TestGenerateTokenForURLRegex(t *testing.T) {
 		t.Errorf("SHA-256 of urlRegex+expiry was wrong. Expected %s, but got %s", expectedSignature, tokenParts[1])
 	}
 
-	b, err := hex.DecodeString(tokenParts[2])
-	if err != nil {
-		t.Errorf("Unexpected error while converting signed URL from Hex: %s", err.Error())
-	}
-	if string(b) != urlToSign {
-		t.Errorf("Expected token to include signed URL of %q, but got %q", urlToSign, string(b))
+	if tokenParts[2] != urlToSign {
+		t.Errorf("Expected token to include signed URL of %q, but got %q", urlToSign, tokenParts[2])
 	}
 }
 


### PR DESCRIPTION
This made it difficult to decode in Fastly VCL and didn't buy us anything